### PR TITLE
Swiping through activities

### DIFF
--- a/app/src/main/java/com/example/colorgame/MainActivity.java
+++ b/app/src/main/java/com/example/colorgame/MainActivity.java
@@ -5,11 +5,15 @@ import androidx.appcompat.widget.Toolbar;
 
 import android.content.Intent;
 import android.os.Bundle;
+import android.view.MotionEvent;
 import android.view.View;
 import android.view.View.OnClickListener;
 import android.widget.Button;
 
 public class MainActivity extends AppCompatActivity {
+
+    // declaring x and y
+    float x1, x2, y1, y2;
 
     private Button solo;
     private Button multiplayer;
@@ -40,6 +44,31 @@ public class MainActivity extends AppCompatActivity {
             }
         });
     }
+
+    // onTouch event: swipe left to open Solo Activity &
+    //                swipe right to open Multiplayer Activity
+    public boolean onTouchEvent(MotionEvent touchEvent){
+        switch(touchEvent.getAction()){
+            case MotionEvent.ACTION_DOWN:
+                x1 = touchEvent.getX();
+                y1 = touchEvent.getY();
+                break;
+            case MotionEvent.ACTION_UP:
+                x2 = touchEvent.getX();
+                y2 = touchEvent.getY();
+                // swipe left
+                if (x1 < x2){
+                    openSoloActivity();
+                }
+                // swipe right
+                else if (x1 > x2){
+                    openMultiplayerActivity();
+                }
+                break;
+        }
+        return false;
+    }
+
     public void openSoloActivity(){
         Intent intent = new Intent(this, SoloActivity.class);
         startActivity(intent);

--- a/app/src/main/java/com/example/colorgame/MultiplayerActivity.java
+++ b/app/src/main/java/com/example/colorgame/MultiplayerActivity.java
@@ -1,6 +1,8 @@
 package com.example.colorgame;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
@@ -10,6 +12,9 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 public class MultiplayerActivity extends AppCompatActivity {
+
+    // declaring x and y
+    float x1, x2, y1, y2;
 
     // players
     private final String playerOne = "Player 1";
@@ -121,6 +126,30 @@ public class MultiplayerActivity extends AppCompatActivity {
         playerTwoScore = 0;
         // reset the text views
         Multiplayer.resetText(playerTurn, playerOnePoints, playerTwoPoints);
+    }
+
+    // onTouch event: swipe left to open Main Activity
+    public boolean onTouchEvent(MotionEvent touchEvent){
+        switch(touchEvent.getAction()){
+            case MotionEvent.ACTION_DOWN:
+                x1 = touchEvent.getX();
+                y1 = touchEvent.getY();
+                break;
+            case MotionEvent.ACTION_UP:
+                x2 = touchEvent.getX();
+                y2 = touchEvent.getY();
+                // swipe left
+                if (x1 < x2){
+                    openMainActivity();
+                }
+                break;
+        }
+        return false;
+    }
+
+    public void openMainActivity(){
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
     }
 
 }

--- a/app/src/main/java/com/example/colorgame/SoloActivity.java
+++ b/app/src/main/java/com/example/colorgame/SoloActivity.java
@@ -1,6 +1,8 @@
 package com.example.colorgame;
 
+import android.content.Intent;
 import android.os.Bundle;
+import android.view.MotionEvent;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
@@ -10,6 +12,11 @@ import androidx.appcompat.app.AppCompatActivity;
 import androidx.appcompat.widget.Toolbar;
 
 public class SoloActivity extends AppCompatActivity {
+
+
+    // declaring x and y
+    float x1, x2, y1, y2;
+
 
     // player stats
     public TextView playerPoints;
@@ -119,4 +126,29 @@ public class SoloActivity extends AppCompatActivity {
         Solo.resetText(winDeclaration, playerPoints, playerLife);
     }
 
+    // onTouch event: swipe right to open Main Activity
+    public boolean onTouchEvent(MotionEvent touchEvent){
+        switch(touchEvent.getAction()){
+            case MotionEvent.ACTION_DOWN:
+                x1 = touchEvent.getX();
+                y1 = touchEvent.getY();
+                break;
+            case MotionEvent.ACTION_UP:
+                x2 = touchEvent.getX();
+                y2 = touchEvent.getY();
+                // swipe right
+                if (x1 > x2){
+                    openMainActivity();
+                }
+                break;
+        }
+        return false;
+    }
+
+    public void openMainActivity(){
+        Intent intent = new Intent(this, MainActivity.class);
+        startActivity(intent);
+    }
+
 }
+


### PR DESCRIPTION
I decided to use a Touch feature as mentioned in issue #17. 
Users can now swipe the screen to enter different activities like this:
``` java
Solo Activity <-- Main Activity --> Multiplayer Activity
```
Swiping left from the home screen will open the Solo Activity, and swiping right from the home screen will open the Multiplayer Activity. Likewise, swiping right from the Solo Activity will open the Main Activity, and swiping left from the Multiplayer Activity will open the Main Activity.  